### PR TITLE
fix(model-catalog): correct Hasura admin secret reference (9.0.0-beta.2)

### DIFF
--- a/charts/mint/Chart.yaml
+++ b/charts/mint/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 9.0.0-beta.1
+version: 9.0.0-beta.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/mint/README.md
+++ b/charts/mint/README.md
@@ -1,6 +1,6 @@
 # MINT
 
-![Version: 9.0.0-beta.1](https://img.shields.io/badge/Version-9.0.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.3](https://img.shields.io/badge/AppVersion-1.16.3-informational?style=flat-square)
+![Version: 9.0.0-beta.2](https://img.shields.io/badge/Version-9.0.0--beta.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.3](https://img.shields.io/badge/AppVersion-1.16.3-informational?style=flat-square)
 
 A Helm chart for MINT
 

--- a/charts/mint/templates/model-catalog.yaml
+++ b/charts/mint/templates/model-catalog.yaml
@@ -79,7 +79,6 @@ spec:
             - name: HASURA_ADMIN_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "mint.prefix" . }}-secrets
-                  key: hasura_admin_secret
-                  optional: true
+                  name: {{ include "mint.prefix" . }}-hasura-secrets
+                  key: admin_secret
 {{ end }}


### PR DESCRIPTION
## Bug

Chart 9.0.0-beta.1 model-catalog Deployment references the wrong Hasura admin secret:

\`\`\`yaml
- name: HASURA_ADMIN_SECRET
  valueFrom:
    secretKeyRef:
      name: {{ include \"mint.prefix\" . }}-secrets         # does not exist
      key: hasura_admin_secret                            # wrong key name
      optional: true                                      # masks the failure
\`\`\`

The chart actually creates \`<prefix>-hasura-secrets\` with key \`admin_secret\` in \`secrets.yaml\`.

\`optional: true\` made the pod start with an empty \`HASURA_ADMIN_SECRET\`, so all queries to Hasura silently failed.

## Fix

- Reference \`<prefix>-hasura-secrets\` with key \`admin_secret\` (matches \`secrets.yaml\` and the existing convention used by ensemble-manager and post-install-hasura).
- Drop \`optional: true\` so a missing secret fails fast at deploy time.
- Bump chart to \`9.0.0-beta.2\`.

## Test plan
- [ ] \`helm lint charts/mint\`
- [ ] \`helm template charts/mint\` renders model-catalog Deployment with the correct secret/key
- [ ] Upgrade dev cluster, confirm model-catalog reads \`HASURA_ADMIN_SECRET\` and queries succeed
- [ ] Verify \`/health\` and a real catalog query (e.g. \`/v2.0.0/modelconfigurationsetups?per_page=1\`) both return 200